### PR TITLE
Fix upper case of "Code of conduct"

### DIFF
--- a/events/202207-tcassp/index.html
+++ b/events/202207-tcassp/index.html
@@ -39,7 +39,7 @@
 <!--                        <li><a href="#presentation">Presentaion</a></li>-->
 <!--                        <li><a href="workshop.html#act">Workshop</a></li>-->
                         <li><a href="#projects">Projects</a></li>
-                        <li><a href="#code">Code of conduct</a></li>
+                        <li><a href="#code">Code of Conduct</a></li>
                     </ul>
                 </nav>
 
@@ -153,7 +153,7 @@
                             <tr><td>Keywords: extra-solar planetary systems</td></tr>
                             <tr><td>Supervisor: Ing-Guey Jiang  (NTHU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p2"><b>2. Effects of Magnetic Field and Viscosity on Ram-pressure Stripping of Galaxies</b></td>
                             </tr>
@@ -165,7 +165,7 @@
                             <tr><td>Keywords: hydrodynamics, magnetohydrodynamics, galaxies</td></tr>
                             <tr><td>Supervisor: Hsiang-Yi Karen Yang (NTHU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p3"><b>3. Dynamical Buoyancy of Globular Clusters in Wave Dark Matter</b></td>
                             </tr>
@@ -176,7 +176,7 @@
                             <tr><td>Keywords: Dark Matter, Galaxies, Numerical Simulations</td></tr>
                             <tr><td>Supervisor: Hsi-Yu Schive (NTU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p4"><b>4. Heating of Stellar Streams by Wave Dark Matter Fluctuations</b></td>
                             </tr>
@@ -188,7 +188,7 @@
                             <tr><td>Keywords: Dark Matter, Galaxies, Numerical Simulations</td></tr>
                             <tr><td>Supervisor: Hsi-Yu Schive (NTU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p5"><b>5. Semi-analytical Models of Forming Planet-forming Disks</b></td>
                             </tr>
@@ -200,7 +200,7 @@
                                 radiative transfer</td></tr>
                             <tr><td>Supervisor: Daniel Harsono (NTHU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p6"><b>6. Properties of Orbiting Hotspots in the Vicinity of Black Holes</b></td>
                             </tr>
@@ -212,7 +212,7 @@
                             <tr><td>Keywords:  black hole, general relativity, numerical method</td></tr>
                             <tr><td>Supervisor: Hung-Yi Pu (NTNU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p7"><b>7. Modeling Emission from Astrophysical Flows around Galaxies</b></td>
                             </tr>
@@ -224,7 +224,7 @@
                             <tr><td>Keywords: Theoretical astrophysics, galaxy evolution, circum-galactic medium</td></tr>
                             <tr><td>Supervisor: Ellis Owen (NTHU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p8"><b>8. Investigating the High-energy Emission from Violent, Star-forming Galaxies</b></td>
                             </tr>
@@ -236,7 +236,7 @@
                             <tr><td>Keywords: Theoretical astrophysics, cosmic rays, gamma-rays, high energy astrophysics, star-forming galaxies, galaxy evolution</td></tr>
                             <tr><td>Supervisor: Ellis Owen (NTHU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p9"><b>9. Polarised Synchrotron Radiation from Ultra-high-energy Particles in Non-thermal Magnetised Intergalactic Media</b></td>
                             </tr>
@@ -248,7 +248,7 @@
                             <tr><td>Keywords: polarised synchrotron radiation, non-thermal processes, ultra-high-energy charged particles, violent galactic starbursts, intergalactic magnetised media</td></tr>
                             <tr><td>Supervisor: Alvina Y. L. On (NTHU/NCTS) &#38; Jennifer Y. H. Chan (U Toronto) </td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p10"><b>10. Rarefied Gas Dynamics of Mass Transport Process on Saturnian Rings</b></td>
                             </tr>
@@ -259,7 +259,7 @@
                             <tr><td>Keywords: Enceladus, Saturn Ring, Numerical Simulations</td></tr>
                             <tr><td>Supervisor: Ian-Lin Lai (NTNU)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p11"><b>11. Noncanonical Methods for Cosmological Parameter Estimation</b></td>
                             </tr>
@@ -270,7 +270,7 @@
                             <tr><td>Keywords: Hubble constant, growth rate, Bayesian statistics, reconstruction method, data analysis, machine learning</td></tr>
                             <tr><td>Supervisor: Reginald Christian Bernardo (ASIoP)</td></tr>
                             <tr><td></td><td></td></tr>
-                        
+
                             <tr>
                                 <td id="p12"><b>12. Chaos in Interstellar Shocks</b></td>
                             </tr>
@@ -281,7 +281,7 @@
                             <tr><td>Keywords: shock, plasma astrophysics, molecular clouds, star-forming regions, interstellar magnetic fields</td></tr>
                             <tr><td>Supervisor: Pin-Gao Gu (ASIAA)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p13"><b>13. "Listening" to Black Hole Portrayal</b></td>
                             </tr>
@@ -292,7 +292,7 @@
                             <tr><td>Keywords: Black holes, gravitational waves, gravitational lensing</td></tr>
                             <tr><td>Supervisor: Che-Yu Chen (ASIoP)</td></tr>
                             <tr><td></td><td></td></tr>
-                            
+
                             <tr>
                                 <td id="p14"><b>14. Gas Outflow with Icy Dust Accelerated/Decelerated by Sublimation</b></td>
                             </tr>
@@ -316,7 +316,7 @@
                         </tbody>
                     </table>
                 </div>
-                                
+
                     </section>
 <!---------Code---------------------------------------------------------------------->
 							<section id="code" class="main">
@@ -325,7 +325,7 @@
 								</header>
 
                                 <p>
-                                The orginizers are committed to making this school productive and enjoyable for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, ethnicity, nationality, age, or religion. Harassment of participants will not be tolerated in any form. 
+                                The orginizers are committed to making this school productive and enjoyable for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, ethnicity, nationality, age, or religion. Harassment of participants will not be tolerated in any form.
                                 </p>
 
 							</section>


### PR DESCRIPTION
The "conduct" is misspelled to lower case in the navbar.
<img width="125" alt="image" src="https://user-images.githubusercontent.com/5615415/162397386-a0b58205-b918-4b63-b8d0-e8cfbe77628f.png">